### PR TITLE
Fix Dockerfile FROM version: pin to 3.9-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-buster
 LABEL maintaner="Florian Purchess <florian@attacke.ventures>"
 
 RUN apt-get update && \


### PR DESCRIPTION
The docker build fails on master branch and v0.4.0.

Package `ufraw-batch` is not available on the new default `3.9-bullseye` and build fails without this change.